### PR TITLE
Custom build urls and remove unused asset ripper field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-﻿# 1.1.16
+﻿# 1.1.17
+
+- Added `CustomBuildUrl` field in `AssetRipperSettings` to allow third-party AssetRipper builds
+- Fixed compatibility with newer AssetRipper versions
+
+# 1.1.16
 
 - Added possible fix for long path names on Windows for File reads and writes
 

--- a/Editor/Steps/Processing/AssetRipperStep.cs
+++ b/Editor/Steps/Processing/AssetRipperStep.cs
@@ -196,8 +196,7 @@ namespace Nomnom.UnityProjectPatcher.Editor.Steps {
         }
 
         private async UniTask DownloadAssetRipper(AssetRipperSettings arSettings) {
-            const string dllUrl = "https://github.com/nomnomab/AssetRipper/releases/download/v1.0.12-patcher/Release.zip";
-            var buildUrl = dllUrl;
+            var buildUrl = arSettings.BuildUrl;
             
             Debug.Log($"Downloading AssetRipper from {buildUrl}");
 

--- a/Runtime/AssetRipper/AssetRipperSettings.cs
+++ b/Runtime/AssetRipper/AssetRipperSettings.cs
@@ -29,11 +29,14 @@ namespace Nomnom.UnityProjectPatcher.AssetRipper {
         public IReadOnlyList<string> FilesToExcludeFromCopy => _filesToExcludeFromCopy.Select(x => x.Replace('/', '\\')).ToList();
         public IReadOnlyList<string> FoldersToExcludeFromRead => _foldersToExcludeFromRead.Select(x => x.Replace('/', '\\')).ToList();
         public IReadOnlyList<string> ProjectSettingFilesToCopy => _projectSettingFilesToCopy.Select(x => x.Replace('/', '\\')).ToList();
-
+        
+        const string defaultBuildUrl = "https://github.com/nomnomab/AssetRipper/releases/download/v1.0.12-patcher/Release.zip";
+        public string BuildUrl => string.IsNullOrWhiteSpace(_customBuildUrl) ? defaultBuildUrl : _customBuildUrl;
+        
         // public bool NeedsManualRip => _configurationData.Processing.enableStaticMeshSeparation;
         // public bool NeedsManualRip => _configurationData.Processing.enableStaticMeshSeparation || _configurationData.Processing.enableStaticMeshSeparation;
         public bool NeedsManualRip => false;
-        
+
         [SerializeField]
         private FolderMapping[] _folderMappings = new[] {
             new FolderMapping(DefaultFolderMapping.AnimationClipKey, DefaultFolderMapping.AnimationClipKey, DefaultFolderMapping.AnimationClipOutput),
@@ -120,6 +123,9 @@ namespace Nomnom.UnityProjectPatcher.AssetRipper {
 
         [SerializeField]
         private AssetRipperJsonData _configurationData = new AssetRipperJsonData();
+
+        [SerializeField] 
+        private string _customBuildUrl = string.Empty;
         
 #if UNITY_2020_3_OR_NEWER
         public bool TryGetFolderMapping(string key, out string folder, out bool exclude, string? fallbackPath = null) {
@@ -226,9 +232,6 @@ namespace Nomnom.UnityProjectPatcher.AssetRipper {
         [JsonProperty("StreamingAssetsMode")]
         [DefaultValue(StreamingAssetsMode.Extract)]
         public StreamingAssetsMode streamingAssetsMode;
-
-        [JsonProperty("DefaultVersion"), HideInInspector]
-        public DefaultVersion defaultVersion;
 
         [JsonProperty("BundledAssetsExportMode")]
         [Tooltip("GroupByAssetType: Bundled assets are treated the same as assets from other files.\n\nGroupByBundleName: Bundled assets are grouped by their asset bundle name.\n\nDirectExport: Bundled assets are exported without grouping.")]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nomnom.unity-project-patcher",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "displayName": "Unity Project Patcher",
   "description": "A tool that generates a Unity project from a game build that can be playable in-editor",
   "unity": "2022.3",


### PR DESCRIPTION
This allows for using newer AssetRipper versions (for example to solve #6).

Sometime since the version the patcher currently uses, AssetRipper switched the formatting of `defaultVersion`, causing a parse error if you run it with unity patcher's current config generation. In this PR I just removed the field, since it was always set to 0 anyway.

This PR also adds the option to set a custom URL to download AssetRipper from. This can be used to utilize a custom version of AssetRipper, without forking this entire repository (or requiring end users to manually download it). For example, I created [my own fork](https://github.com/Kesomannen/AssetRipper), with the same changes applied as [the "official" one](https://github.com/nomnomab/AssetRipper), but for a newer version of AssetRipper in order to solve the aforementioned issue.